### PR TITLE
Able to get info for all types of Curve pools

### DIFF
--- a/models/credmark/protocols/dexes/curve/curve_finance.py
+++ b/models/credmark/protocols/dexes/curve/curve_finance.py
@@ -218,8 +218,8 @@ class CurveFinanceTotalTokenLiqudity(Model):
 
         all_pools_info = CurveFiPoolInfos(pool_infos=pool_infos)
 
-        (pd.DataFrame((all_pools_info.dict())['pool_infos'])
-         .to_csv(f'tmp/curve-all-info_{self.context.block_number}.csv'))
+        # (pd.DataFrame((all_pools_info.dict())['pool_infos'])
+        # .to_csv(f'tmp/curve-all-info_{self.context.block_number}.csv'))
         return all_pools_info
 
 

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
@@ -112,6 +112,8 @@ class UniswapV3GetPoolInfo(Model):
         slot0 = pool.functions.slot0().call()
         fee = pool.functions.fee().call()
         ticks = pool.functions.ticks(slot0[1]).call()
+        _liquidityGross = ticks[0]
+        _liquidityNet = ticks[1]
 
         token0_addr = pool.functions.token0().call()
         token1_addr = pool.functions.token1().call()
@@ -172,8 +174,6 @@ class UniswapV3GetPoolInfo(Model):
             'tick_liquidity_token0': adjusted_amount0,
             'tick_liquidity_token1': adjusted_amount1,
             "fee": fee,
-            'liquidityGross': ticks[0],
-            'liquidityNet': ticks[1],
             'virtual_liquidity_token0': virtual_x,
             'virtual_liquidity_token1': virtual_y,
         }

--- a/test/test_account_token.sh
+++ b/test/test_account_token.sh
@@ -12,6 +12,7 @@ echo_cmd "Run Token Examples:"
 echo_cmd ""
 
 test_model 0 token.price '{"symbol": "WETH"}' ${token_price_deps}
+test_model 0 token.price '{"address":"0x7bea39867e4169dbe237d55c8242a8f2fcdcc387"}' ${token_price_deps}
 test_model 0 token.price '{"symbol": "CMK"}' ${token_price_deps}
 test_model 0 token.price '{"symbol": "AAVE"}' ${token_price_deps}
 # AAVE: 0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9

--- a/test/test_curve.sh
+++ b/test/test_curve.sh
@@ -14,6 +14,6 @@ test_model 0 curve-fi.gauge-yield '{"address":"0x824F13f1a2F29cFEEa81154b46C0fc8
 test_model 0 curve-fi.all-gauge-claim-addresses '{"address":"0x824F13f1a2F29cFEEa81154b46C0fc820677A637"}'
 # 0x72E158d38dbd50A483501c24f792bDAAA3e7D55C is Curve.fi FRAX3CRV-f Gauge Deposit (FRAX3CRV-...)
 test_model 0 curve-fi.all-gauge-claim-addresses '{"address":"0x72E158d38dbd50A483501c24f792bDAAA3e7D55C"}'
-test_model 0 contrib.nish-curve-get-pegging-ratio '{"address": "0xfd5db7463a3ab53fd211b4af195c5bccc1a03890"}'
-test_model 0 contrib.nish-curve-get-pegging-ratio-historical '{"pool": {"address": "0xfd5db7463a3ab53fd211b4af195c5bccc1a03890"}, "date_range": ["2022-01-10","2022-01-15"]}'
-test_model 0 contrib.nish-curve-get-depegging-amount '{"pool": {"address": "0xfd5db7463a3ab53fd211b4af195c5bccc1a03890"},"token": {"address": "0xd71ecff9342a5ced620049e616c5035f1db98620"}, "desired_ratio": 0.98485645}'
+test_model 0 contrib.curve-get-pegging-ratio '{"address": "0xfd5db7463a3ab53fd211b4af195c5bccc1a03890"}'
+test_model 0 contrib.curve-get-pegging-ratio-historical '{"pool": {"address": "0xfd5db7463a3ab53fd211b4af195c5bccc1a03890"}, "date_range": ["2022-01-10","2022-01-15"]}'
+test_model 0 contrib.curve-get-depegging-amount '{"pool": {"address": "0xfd5db7463a3ab53fd211b4af195c5bccc1a03890"},"token": {"address": "0xd71ecff9342a5ced620049e616c5035f1db98620"}, "desired_ratio": 0.98485645}'


### PR DESCRIPTION
Curve's API is incomplete:
- pool.get_underlying_token() is missing for some pools like 3Crv. => Call registry to get it
- pool's ABI are inconsistent due to version and pool types.
  - name() is missing for some pools
   - lp_token() are internal function for some pools.
   - Special setting for USD-BTC-ETH pool.
- Token address '0xeee...' for ETH will return hard-code symbol 'eeeETH'.

**Test**

```
credmark-dev run curve-fi.pool-info -i '{"address":"0x8474DdbE98F5aA3179B3B3F5942D724aFcdec9f6"}' -j
> Curve.fi MUSD/3Crv

credmark-dev run curve-fi.pool-info -i '{"address":"0x42d7025938bEc20B69cBae5A77421082407f053A"}' -j
> USDP/3crv  

credmark-dev run curve-fi.pool-info -i '{"address":"0x0f9cb53Ebe405d49A0bbdBD291A65Ff571bC83e1"}' -j
> USDN/3Crv  

credmark-dev run curve-fi.pool-info -i '{"address":"0x80466c64868e1ab14a1ddf27a676c3fcbe638fe5"}' -j -b 14234904  

credmark-dev run curve-fi.all-pools-info -j -l curve-fi.pool-info

credmark-dev run curve-fi.all-pools-info -j -l curve-fi.pool-info -b 14234904 
```