### PR TITLE
VaR model for portfolio

### DIFF
--- a/models/credmark/algorithms/value_at_risk/dto.py
+++ b/models/credmark/algorithms/value_at_risk/dto.py
@@ -5,6 +5,7 @@ from credmark.dto import (
     DTO,
     IterableListGenericDTO,
     PrivateAttr,
+    cross_examples,
 )
 
 from credmark.cmf.types import (
@@ -36,9 +37,22 @@ class ContractVaRInput(DTO):
 
     class Config:
         schema_extra = {
-            'examples': [{'asOf': '2022-02-17',
-                          'window': '2 days',
-                          'interval': 1,
-                          'confidences': [0.01, 0.05]
-                          }]
+            'examples': [
+                {'asOf': '2022-02-17',
+                 'window': '2 days',
+                 'interval': 1,
+                 'confidences': [0.01, 0.05]
+                 }]
+        }
+
+
+class PortfolioVaRInput(ContractVaRInput):
+    portfolio: Portfolio
+
+    class Config:
+        schema_extra = {
+            'examples': cross_examples(ContractVaRInput.Config.schema_extra['examples'],
+                                       [{'portfolio': v}
+                                           for v in Portfolio.Config.schema_extra['examples']],
+                                       limit=10)
         }

--- a/models/credmark/algorithms/value_at_risk/var_demo.py
+++ b/models/credmark/algorithms/value_at_risk/var_demo.py
@@ -2,17 +2,21 @@ import json
 
 from credmark.cmf.model import Model
 
+from credmark.cmf.model.errors import ModelRunError
+
 from credmark.cmf.types import (
     Portfolio,
     Token,
     Position,
     PriceList,
+    Price,
 )
 
 from models.credmark.algorithms.value_at_risk.dto import (
     HistoricalPriceInput,
     VaRHistoricalInput,
     ContractVaRInput,
+    PortfolioVaRInput,
 )
 
 
@@ -37,6 +41,48 @@ class VaRPriceHistorical(Model):
             tokenAddress=token.address,
             src=self.slug
         )
+
+
+@Model.describe(slug='finance.var-portfolio',
+                version='1.0',
+                display_name='Value at Risk - for a portfolio',
+                description='Calculate VaR based on input portfolio',
+                input=PortfolioVaRInput,
+                output=dict)
+class VaRPortfolio(Model):
+    def run(self, input: PortfolioVaRInput) -> dict:
+        # Get the portfolio as of the input.asOf. Below is example input.
+        portfolio = input.portfolio
+
+        pls = []
+        pl_assets = set()
+        for pos in portfolio:
+            if pos.asset.address not in pl_assets:
+                hp = self.context.historical.run_model_historical(model_slug='token.price',
+                                                                  model_input=pos.asset,
+                                                                  window=input.window,
+                                                                  model_return_type=Price)
+                ps = [p.output.price for p in hp if p.output.price is not None][::-1]
+                if len(ps) < len(hp.series):
+                    raise ModelRunError('Received None output for token price.'
+                                        'Check the series '
+                                        f'{[(p.output.price,p.blockNumber) for p in hp]}')
+                pl = PriceList(prices=ps,
+                               tokenAddress=pos.asset.address,
+                               src=list({p.output.src for p in hp})[0])
+                pls.append(pl)
+                pl_assets.add(pos.asset.address)
+
+        var_input = VaRHistoricalInput(
+            portfolio=portfolio,
+            priceLists=pls,
+            interval=input.interval,
+            confidences=input.confidences,
+        )
+
+        return self.context.run_model(slug='finance.var-engine-historical',
+                                      input=var_input,
+                                      return_type=dict)
 
 
 @Model.describe(slug='finance.example-var-contract',

--- a/test/test_finance.sh
+++ b/test/test_finance.sh
@@ -4,4 +4,8 @@ echo_cmd ""
 
 test_model 0 finance.example-var-contract '{"asOf": "2022-02-17", "window": "30 days", "interval": 3, "confidences": [0.01,0.05]}' finance.example-var-contract,finance.example-historical-price,finance.var-engine-historical
 test_model 0 finance.lcr '{"address": "0xe78388b4ce79068e89bf8aa7f218ef6b9ab0e9d0", "cashflow_shock": 1e10}'
+test_model 0 finance.min-risk-rate '{}' compound-v2.get-pool-info,compound-v2.all-pools-info
 test_model 0 finance.var-aave '{"asOf": "2022-02-17", "window": "30 days", "interval": 3, "confidences": [0.01,0.05]}' finance.example-var-contract,finance.example-historical-price,finance.var-engine-historical
+test_model 0 finance.var-compound '{"asOf": "2022-02-17", "window": "30 days", "interval": 3, "confidences": [0.01,0.05]}' finance.example-var-contract,finance.example-historical-price,finance.var-engine-historical
+test_model 0 finance.sharpe-ratio-token '{"token": {"address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"}, "return_rolling_days": 180, "risk_free_rate": 0.02}'
+test_model 0 finance.var-portfolio '{"asOf": "2022-02-17", "window": "20 days", "interval": 1, "confidences": [0,0.01,0.05,1], "portfolio": {"positions": [{"amount": "0.5", "asset": {"symbol": "WBTC"}}, {"amount": "0.5", "asset": {"symbol": "WETH"}}]}}

--- a/test/test_finance.sh
+++ b/test/test_finance.sh
@@ -8,4 +8,4 @@ test_model 0 finance.min-risk-rate '{}' compound-v2.get-pool-info,compound-v2.al
 test_model 0 finance.var-aave '{"asOf": "2022-02-17", "window": "30 days", "interval": 3, "confidences": [0.01,0.05]}' finance.example-var-contract,finance.example-historical-price,finance.var-engine-historical
 test_model 0 finance.var-compound '{"asOf": "2022-02-17", "window": "30 days", "interval": 3, "confidences": [0.01,0.05]}' finance.example-var-contract,finance.example-historical-price,finance.var-engine-historical
 test_model 0 finance.sharpe-ratio-token '{"token": {"address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"}, "return_rolling_days": 180, "risk_free_rate": 0.02}'
-test_model 0 finance.var-portfolio '{"asOf": "2022-02-17", "window": "20 days", "interval": 1, "confidences": [0,0.01,0.05,1], "portfolio": {"positions": [{"amount": "0.5", "asset": {"symbol": "WBTC"}}, {"amount": "0.5", "asset": {"symbol": "WETH"}}]}}
+test_model 0 finance.var-portfolio '{"asOf": "2022-02-17", "window": "20 days", "interval": 1, "confidences": [0,0.01,0.05,1], "portfolio": {"positions": [{"amount": "0.5", "asset": {"symbol": "WBTC"}}, {"amount": "0.5", "asset": {"symbol": "WETH"}}]}}'


### PR DESCRIPTION
Add a model to calculate VaR for a portfolio. We will add this to risk terminal for a demo portfolio of ETH and BTC.

**Test**

```
credmark-dev run finance.var-portfolio --input '{"asOf": "2022-02-17", "window": "20 days", "interval": 1, "confidences": [0.01], \
"portfolio": {"positions": [{"amount": "0.5", "asset": {"symbol": "WBTC"}}, {"amount": "0.5", "asset": {"symbol": "WETH"}}]}}' -b 14234904 --format_json
```

**Output**

```
    "output": {
        "0.0": -1683.414697815728,
        "0.01": -1554.1772644205168,
        "0.05": -1037.227530839672,
        "1.0": 2513.3251030827328
    },

```