### PR TITLE
Chainlink oracle

### DIFF
--- a/models/credmark/protocols/credmark/vesting.py
+++ b/models/credmark/protocols/credmark/vesting.py
@@ -110,7 +110,7 @@ class CMKGetVestingByAccount(Model):
         token = Token(symbol="CMK")
         claims = []
         current_price = Price(**self.context.models.uniswap_v3.get_average_price(
-                        input={"symbol":"CMK"})).price
+            input={"symbol": "CMK"})).price
         for vesting_contract in vesting_contracts:
             if vesting_contract.functions.getElapsedVestingTime(input.address).call() == 0:
                 continue
@@ -138,23 +138,23 @@ class CMKGetVestingByAccount(Model):
                     vesting_contract.functions.getClaimableAmount(input.address).call()
                 ))
             result.vesting_infos.append(vesting_info)
-            claims_all= [
+            claims_all = [
                 dict(d['args']) for d in
                 vesting_contract.events.AllocationClaimed.createFilter(
                     fromBlock=0, toBlock=self.context.block_number
-                    ).get_all_entries()]
+                ).get_all_entries()]
             for c in claims_all:
                 if c['account'] == input.address:
                     c['amount'] = Token(symbol="CMK").scaled(c['amount'])
                     c['value_at_claim_time'] = c['amount'] * self.context.run_model(
                         slug="uniswap-v3.get-average-price",
-                        input={"symbol":"CMK"},
+                        input={"symbol": "CMK"},
                         block_number=self.context.block_number.from_timestamp(c['timestamp']),
                         return_type=Price).price
                     c['value_now'] = c['amount'] * current_price
                     claims.append(c)
         result.claims = claims
-        
+
         return result
 
 

--- a/models/credmark/protocols/lending/aave/aave_v2.py
+++ b/models/credmark/protocols/lending/aave/aave_v2.py
@@ -1,3 +1,4 @@
+from typing import List, Optional
 from credmark.cmf.model import Model
 from credmark.cmf.model.errors import ModelDataError, ModelRunError
 from credmark.cmf.types import Address, Contract, Contracts, Portfolio, Position, Token, Price
@@ -120,7 +121,7 @@ class AaveV2GetPriceOracle(Model):
 @Model.describe(slug="aave-v2.get-oracle-price",
                 version="1.1",
                 display_name="Aave V2 - Query price oracle for main market - in ETH",
-                description="Price Token / ETH",
+                description="Price of Token / ETH",
                 input=Token,
                 output=Price)
 class AaveV2GetOraclePrice(Model):
@@ -128,9 +129,7 @@ class AaveV2GetOraclePrice(Model):
         oracle = Contract(**self.context.models.aave_v2.get_price_oracle())
         price = oracle.functions.getAssetPrice(input.address).call()
         source = oracle.functions.getSourceOfAsset(input.address).call()
-
-        return Price(price=price / 1e18,
-                     src=f'{self.slug}|{source}')
+        return Price(price=price / 1e18, src=f'{self.slug}|{source}')
 
 
 def get_eip1967_implementation(context, logger, token_address):

--- a/models/credmark/protocols/lending/aave/aave_v2.py
+++ b/models/credmark/protocols/lending/aave/aave_v2.py
@@ -1,6 +1,3 @@
-from queue import Empty
-from typing import List, Optional
-
 from credmark.cmf.model import Model
 from credmark.cmf.model.errors import ModelDataError, ModelRunError
 from credmark.cmf.types import Address, Contract, Contracts, Portfolio, Position, Token, Price
@@ -122,8 +119,8 @@ class AaveV2GetPriceOracle(Model):
 
 @Model.describe(slug="aave-v2.get-oracle-price",
                 version="1.1",
-                display_name="Aave V2 - Query price oracle for main market",
-                description="Aave V2 - Query price oracle for main market",
+                display_name="Aave V2 - Query price oracle for main market - in ETH",
+                description="Price Token / ETH",
                 input=Token,
                 output=Price)
 class AaveV2GetOraclePrice(Model):
@@ -132,8 +129,7 @@ class AaveV2GetOraclePrice(Model):
         price = oracle.functions.getAssetPrice(input.address).call()
         source = oracle.functions.getSourceOfAsset(input.address).call()
 
-        weth_usd = Price(**self.context.models.chainlink.eth_usd())
-        return Price(price=price / 1e18 * weth_usd.price,
+        return Price(price=price / 1e18,
                      src=f'{self.slug}|{source}')
 
 

--- a/models/credmark/protocols/oracle/chainlink.py
+++ b/models/credmark/protocols/oracle/chainlink.py
@@ -33,7 +33,7 @@ class ChainLinkFeedPrice(Model):
     GBP = Address('0x{:040x}'.format(826))
     EUR = Address('0x{:040x}'.format(978))
 
-    def run(self, input) -> Contract:
+    def run(self, input: Token) -> Price:
         registry = Contract(**self.context.models.chainlink.get_feed_registry())
         (_roundId, answer,
          _startedAt, _updatedAt,
@@ -46,4 +46,5 @@ class ChainLinkFeedPrice(Model):
         time_diff = self.context.block_number.timestamp - _updatedAt
         round_diff = _answeredInRound - _roundId
         return Price(price=answer / (10 ** decimals),
-                     src=f'{self.slug}|{description}|{feed}|v{version}|{isFeedEnabled}|t:{time_diff}s|r:{round_diff}')
+                     src=(f'{self.slug}|{description}|{feed}|v{version}|'
+                          f'{isFeedEnabled}|t:{time_diff}s|r:{round_diff}'))

--- a/models/credmark/protocols/oracle/chainlink.py
+++ b/models/credmark/protocols/oracle/chainlink.py
@@ -1,0 +1,47 @@
+from credmark.cmf.model import Model
+from credmark.cmf.types import Contract, Price
+from credmark.dto import  EmptyInput
+
+
+@Model.describe(slug="chainlink.eth-usd",
+                version="1.0",
+                display_name="Chainlink - ETH / USD",
+                description="Chainlink - ETH / USD",
+                input=EmptyInput,
+                output=Price)
+class ChainLinkETHUSD(Model):
+    CHAINLINK_ETH_USD = {
+        1: '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419',
+        4: '0x8A753747A1Fa494EC906cE90E9f37563A8AF630e',  # Rinkeby
+        42: '0x9326BFA02ADD2366b30bacB125260Af641031331',  # Kovan
+    }
+
+    def run(self, _) -> Price:
+        oracle = Contract(address=self.CHAINLINK_ETH_USD[self.context.chain_id])
+        (_roundId, answer,
+         _startedAt, _updatedAt, _answeredInRound) = oracle.functions.latestRoundData().call()
+        decimals = oracle.functions.decimals().call()
+        return Price(price=answer / (10 ** decimals),
+                     src=f'{self.slug}')
+
+
+@Model.describe(slug="chainlink.btc-usd",
+                version="1.0",
+                display_name="Chainlink - BTC / USD",
+                description="Chainlink - BTC / USD",
+                input=EmptyInput,
+                output=Price)
+class ChainLinkBTCUSD(Model):
+    CHAINLINK_BTC_USD = {
+        1: '0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c',
+        4: '0xECe365B379E1dD183B20fc5f022230C044d51404',  # Rinkeby
+        42: '0x6135b13325bfC4B00278B4abC5e20bbce2D6580e',  # Kovan
+    }
+
+    def run(self, _) -> Price:
+        oracle = Contract(address=self.CHAINLINK_BTC_USD[self.context.chain_id])
+        (_roundId, answer,
+         _startedAt, _updatedAt, _answeredInRound) = oracle.functions.latestRoundData().call()
+        decimals = oracle.functions.decimals().call()
+        return Price(price=answer / (10 ** decimals),
+                     src=f'{self.slug}')

--- a/models/credmark/protocols/oracle/chainlink.py
+++ b/models/credmark/protocols/oracle/chainlink.py
@@ -1,47 +1,49 @@
 from credmark.cmf.model import Model
-from credmark.cmf.types import Contract, Price
-from credmark.dto import  EmptyInput
+from credmark.cmf.types import Contract, Price, Token, Address
+from credmark.dto import EmptyInput
 
 
-@Model.describe(slug="chainlink.eth-usd",
+@Model.describe(slug='chainlink.get-feed-registry',
                 version="1.0",
-                display_name="Chainlink - ETH / USD",
-                description="Chainlink - ETH / USD",
+                display_name="Chainlink - Feed registry",
+                description="Supports multi-chain",
                 input=EmptyInput,
-                output=Price)
-class ChainLinkETHUSD(Model):
-    CHAINLINK_ETH_USD = {
-        1: '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419',
-        4: '0x8A753747A1Fa494EC906cE90E9f37563A8AF630e',  # Rinkeby
-        42: '0x9326BFA02ADD2366b30bacB125260Af641031331',  # Kovan
+                output=Contract)
+class ChainLinkFeedRegistry(Model):
+    CHAINLINK_REGISTRY = {
+        1: '0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf',
+        42: '0xAa7F6f7f507457a1EE157fE97F6c7DB2BEec5cD0'
     }
 
-    def run(self, _) -> Price:
-        oracle = Contract(address=self.CHAINLINK_ETH_USD[self.context.chain_id])
-        (_roundId, answer,
-         _startedAt, _updatedAt, _answeredInRound) = oracle.functions.latestRoundData().call()
-        decimals = oracle.functions.decimals().call()
-        return Price(price=answer / (10 ** decimals),
-                     src=f'{self.slug}')
+    def run(self, _) -> Contract:
+        return Contract(address=self.CHAINLINK_REGISTRY[self.context.chain_id])
 
 
-@Model.describe(slug="chainlink.btc-usd",
+@Model.describe(slug='chainlink.price-usd',
                 version="1.0",
-                display_name="Chainlink - BTC / USD",
-                description="Chainlink - BTC / USD",
-                input=EmptyInput,
+                display_name="Chainlink - Price for Token / USD pair",
+                description="",
+                input=Token,
                 output=Price)
-class ChainLinkBTCUSD(Model):
-    CHAINLINK_BTC_USD = {
-        1: '0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c',
-        4: '0xECe365B379E1dD183B20fc5f022230C044d51404',  # Rinkeby
-        42: '0x6135b13325bfC4B00278B4abC5e20bbce2D6580e',  # Kovan
-    }
+class ChainLinkFeedPrice(Model):
+    ETH = Address('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE')
+    BTC = Address('0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB')
 
-    def run(self, _) -> Price:
-        oracle = Contract(address=self.CHAINLINK_BTC_USD[self.context.chain_id])
+    USD = Address('0x{:040x}'.format(840))
+    GBP = Address('0x{:040x}'.format(826))
+    EUR = Address('0x{:040x}'.format(978))
+
+    def run(self, input) -> Contract:
+        registry = Contract(**self.context.models.chainlink.get_feed_registry())
         (_roundId, answer,
-         _startedAt, _updatedAt, _answeredInRound) = oracle.functions.latestRoundData().call()
-        decimals = oracle.functions.decimals().call()
+         _startedAt, _updatedAt,
+         _answeredInRound) = registry.functions.latestRoundData(input.address, self.USD).call()
+        decimals = registry.functions.decimals(input.address, self.USD).call()
+        description = registry.functions.description(input.address, self.USD).call()
+        version = registry.functions.version(input.address, self.USD).call()
+        feed = registry.functions.getFeed(input.address, self.USD).call()
+        isFeedEnabled = registry.functions.isFeedEnabled(feed).call()
+        time_diff = self.context.block_number.timestamp - _updatedAt
+        round_diff = _answeredInRound - _roundId
         return Price(price=answer / (10 ** decimals),
-                     src=f'{self.slug}')
+                     src=f'{self.slug}|{description}|{feed}|v{version}|{isFeedEnabled}|t:{time_diff}s|r:{round_diff}')


### PR DESCRIPTION
A fast model for price, for review and improvement.

1/ Chainlink
- Tried feed registry but some tokens are not found, e.g. AVAX
- Easier if we could use ENS name, e.g. `crv-eth.data.eth`. @abhishektvz  team is working on it?

2/ Aave has an interface to Chainlink. https://docs.aave.com/developers/v/1.0/developing-on-aave/the-protocol/price-oracle
Aave uses Token/ETH pair and some of them are not frequently updated.
- CRV / USD: last updated 11 mins. https://data.chain.link/ethereum/mainnet/crypto-usd/crv-usd
- CRV / ETH: last updated 11 hours: https://data.chain.link/ethereum/mainnet/crypto-eth/crv-eth
