### PR TITLE
models update and fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# PyCharmm
 .idea/
 
 # model manifest

--- a/models/contrib/neilz/example_contribution.py
+++ b/models/contrib/neilz/example_contribution.py
@@ -1,4 +1,5 @@
 from credmark.cmf.model import Model
+from credmark.dto import EmptyInput
 
 
 @Model.describe(
@@ -12,7 +13,7 @@ from credmark.cmf.model import Model
     output=dict
 )
 class MyModel(Model):
-    def run(self, input):
+    def run(self, _: EmptyInput):
         return {
             "credmarkFounder": "Neil",
             "message": "You are a modeler. Thank you modeler."

--- a/models/credmark/algorithms/value_at_risk/var_dex_lp.py
+++ b/models/credmark/algorithms/value_at_risk/var_dex_lp.py
@@ -62,7 +62,7 @@ class UniswapPoolVaR(Model):
                                              return_type=UniswapV3PoolInfo)
             scale_multiplier = (10 ** (v3_info.token0.decimals - v3_info.token1.decimals))
             # p_0 = tick_price = token0 / token1
-            p_0 = 1.0001 ** v3_info.tick * scale_multiplier
+            p_0 = 1.0001 ** v3_info.current_tick * scale_multiplier
 
         t_unit, count = self.context.historical.parse_timerangestr(input.window)
         interval = self.context.historical.range_timestamp(t_unit, 1)

--- a/models/credmark/price/dex.py
+++ b/models/credmark/price/dex.py
@@ -1,4 +1,5 @@
 # pylint: disable=locally-disabled
+import sys
 from abc import abstractmethod
 from typing import List
 
@@ -79,7 +80,8 @@ class PoolPriceAggregator(Model):
         if len(input.some) == 1:
             return Price(price=df.price_t[0], src=price_src)
 
-        breakpoint()
+        if input.debug:
+            print(df, file=sys.stderr)
 
         if len(zero_pools) == len(all_pool_infos):
             return Price(price=df.price_t.min(), src=price_src)
@@ -271,7 +273,8 @@ class PriceFromDexModel(Model, PriceWeight):
         pool_aggregator_input = PoolPriceAggregatorInput(
             some=all_pool_infos,
             token=input,
-            weight_power=self.WEIGHT_POWER)
+            weight_power=self.WEIGHT_POWER,
+            debug=False)
 
         # return PoolPriceAggregator(self.context).run(pool_aggregator_input)
         return self.context.run_model('price.pool-aggregator',

--- a/models/credmark/price/dex.py
+++ b/models/credmark/price/dex.py
@@ -2,39 +2,92 @@
 from abc import abstractmethod
 from typing import List
 
-import pandas as pd
 from credmark.cmf.model import Model
 from credmark.cmf.model.errors import ModelRunError
-from credmark.cmf.types import Maybe, Price, Some, Token
+from credmark.cmf.types import Address, Maybe, Network, Price, Some, Token
+from credmark.cmf.types.block_number import BlockNumberOutOfRangeError
 from credmark.cmf.types.compose import MapInputsOutput
 from models.dtos.price import (PRICE_DATA_ERROR_DESC, PoolPriceAggregatorInput,
                                PoolPriceInfo)
+
+
+@Model.describe(slug='dex.primary-tokens',
+                version='0.1',
+                display_name='Dex Primary Tokens',
+                description='Tokens as primary trading pair',
+                category='protocol',
+                subcategory='dex',
+                tags=['uniswap-v2', 'uniswap-v3', 'sushiswap'],
+                output=Some[Address])
+class DexPrimaryTokens(Model):
+    PRIMARY_TOKENS = {
+        Network.Mainnet: (lambda: [Token('USDC'), Token('DAI'), Token('USDT')])
+    }
+
+    def run(self, _) -> Some[Address]:
+        valid_tokens = []
+        for t in self.PRIMARY_TOKENS[self.context.network]():
+            try:
+                _ = (t.deployed_block_number is not None and
+                     t.deployed_block_number >= self.context.block_number)
+                valid_tokens.append(t.address)
+            except BlockNumberOutOfRangeError:
+                pass
+        return Some(some=valid_tokens)
 
 
 @Model.describe(slug='price.pool-aggregator',
                 version='1.4',
                 display_name='Token Price from DEX pools, weighted by liquidity',
                 description='Aggregate prices from pools weighted by liquidity',
-                input=PoolPriceAggregatorInput,
                 category='protocol',
                 subcategory='compound',
                 tags=['price'],
+                input=PoolPriceAggregatorInput,
                 output=Price,
                 errors=PRICE_DATA_ERROR_DESC)
 class PoolPriceAggregator(Model):
     def run(self, input: PoolPriceAggregatorInput) -> Price:
-        if len(input.some) == 0:
-            raise ModelRunError(f'No pool to aggregate for {input.token}')
+        all_pool_infos = input.some
 
-        df = pd.DataFrame(input.dict()['some'])
+        if len(all_pool_infos) == 0:
+            raise ModelRunError(f'No pool to aggregate for {input}')
+
+        non_zero_pools = {
+            ii.pool_address for ii in all_pool_infos
+            if (ii.token0_address == input.token.address and ii.one_tick_liquidity0 > 0) or
+            (ii.token1_address == input.token.address and ii.one_tick_liquidity1 > 0)}
+
+        zero_pools = {
+            ii.pool_address for ii in all_pool_infos
+            if (ii.token0_address == input.token.address and ii.one_tick_liquidity0 == 0) or
+            (ii.token1_address == input.token.address and ii.one_tick_liquidity1 == 0)}
+
+        price_src = (f'{self.slug}|'
+                     f'Non-zero:{len(non_zero_pools)}|'
+                     f'Zero:{len(zero_pools)}')
+
+        df = (Some(some=input.some)
+              .to_dataframe()
+              .assign(
+            price_t=lambda x: x.price_usd0.where(x.token0_address == input.token.address,
+                                                 x.price_usd1),
+            tick_liquidity_t=lambda x: x.one_tick_liquidity0.where(
+                x.token0_address == input.token.address, x.one_tick_liquidity1))
+              )
 
         if len(input.some) == 1:
-            return Price(price=input.some[0].price, src=input.price_src)
+            return Price(price=df.price_t[0], src=price_src)
 
-        product_of_price_liquidity = (df.price * df.tick_liquidity ** input.weight_power).sum()
-        sum_of_liquidity = (df.tick_liquidity ** input.weight_power).sum()
+        breakpoint()
+
+        if len(zero_pools) == len(all_pool_infos):
+            return Price(price=df.price_t.min(), src=price_src)
+
+        product_of_price_liquidity = (df.price_t * df.tick_liquidity_t ** input.weight_power).sum()
+        sum_of_liquidity = (df.tick_liquidity_t ** input.weight_power).sum()
         price = product_of_price_liquidity / sum_of_liquidity
-        return Price(price=price, src=input.price_src)
+        return Price(price=price, src=price_src)
 
 
 class PriceWeight:
@@ -54,7 +107,6 @@ class DexWeightedPrice(Model, PriceWeight):
 
         pool_aggregator_input = PoolPriceAggregatorInput(token=input,
                                                          **pool_price_infos,
-                                                         price_src=self.slug,
                                                          weight_power=self.WEIGHT_POWER)
         return self.context.run_model('price.pool-aggregator',
                                       input=pool_aggregator_input,
@@ -62,61 +114,61 @@ class DexWeightedPrice(Model, PriceWeight):
                                       local=True)
 
 
-@Model.describe(slug='uniswap-v3.get-weighted-price',
-                version='1.2',
-                display_name='Uniswap v3 - get price weighted by liquidity',
-                description='The Uniswap v3 pools that support a token contract',
-                category='protocol',
-                subcategory='uniswap-v3',
-                tags=['price'],
-                input=Token,
-                output=Price,
-                errors=PRICE_DATA_ERROR_DESC)
+@ Model.describe(slug='uniswap-v3.get-weighted-price',
+                 version='1.2',
+                 display_name='Uniswap v3 - get price weighted by liquidity',
+                 description='The Uniswap v3 pools that support a token contract',
+                 category='protocol',
+                 subcategory='uniswap-v3',
+                 tags=['price'],
+                 input=Token,
+                 output=Price,
+                 errors=PRICE_DATA_ERROR_DESC)
 class UniswapV3WeightedPrice(DexWeightedPrice):
     def run(self, input: Token) -> Price:
         return self.aggregate_pool('uniswap-v3.get-pool-info-token-price', input)
 
 
-@Model.describe(slug='uniswap-v2.get-weighted-price',
-                version='1.2',
-                display_name='Uniswap v2 - get price weighted by liquidity',
-                description='The Uniswap v2 pools that support a token contract',
-                category='protocol',
-                subcategory='uniswap-v2',
-                tags=['price'],
-                input=Token,
-                output=Price,
-                errors=PRICE_DATA_ERROR_DESC)
+@ Model.describe(slug='uniswap-v2.get-weighted-price',
+                 version='1.2',
+                 display_name='Uniswap v2 - get price weighted by liquidity',
+                 description='The Uniswap v2 pools that support a token contract',
+                 category='protocol',
+                 subcategory='uniswap-v2',
+                 tags=['price'],
+                 input=Token,
+                 output=Price,
+                 errors=PRICE_DATA_ERROR_DESC)
 class UniswapV2WeightedPrice(DexWeightedPrice):
     def run(self, input: Token) -> Price:
         return self.aggregate_pool('uniswap-v2.get-pool-info-token-price', input)
 
 
-@Model.describe(slug='sushiswap.get-weighted-price',
-                version='1.2',
-                display_name='Sushi v2 (Uniswap V2) - get price weighted by liquidity',
-                description='The Sushi v2 pools that support a token contract',
-                category='protocol',
-                subcategory='sushi-v2',
-                tags=['price'],
-                input=Token,
-                output=Price,
-                errors=PRICE_DATA_ERROR_DESC)
+@ Model.describe(slug='sushiswap.get-weighted-price',
+                 version='1.2',
+                 display_name='Sushi v2 (Uniswap V2) - get price weighted by liquidity',
+                 description='The Sushi v2 pools that support a token contract',
+                 category='protocol',
+                 subcategory='sushi-v2',
+                 tags=['price'],
+                 input=Token,
+                 output=Price,
+                 errors=PRICE_DATA_ERROR_DESC)
 class SushiV2GetAveragePrice(DexWeightedPrice):
     def run(self, input: Token) -> Price:
         return self.aggregate_pool('sushiswap.get-pool-info-token-price', input)
 
 
-@Model.describe(slug='price.dex-pool',
-                version='0.1',
-                display_name='',
-                description='The Current Credmark Supported Price Algorithms',
-                developer='Credmark',
-                category='price',
-                subcategory='dex',
-                tags=['dex', 'price'],
-                input=Token,
-                output=Some[PoolPriceInfo])
+@ Model.describe(slug='price.dex-pool',
+                 version='0.1',
+                 display_name='',
+                 description='The Current Credmark Supported Price Algorithms',
+                 developer='Credmark',
+                 category='price',
+                 subcategory='dex',
+                 tags=['dex', 'price'],
+                 input=Token,
+                 output=Some[PoolPriceInfo])
 class PriceInfoFromDex(Model):
     DEX_POOL_PRICE_INFO_MODELS: List[str] = ['uniswap-v2.get-pool-info-token-price',
                                              'sushiswap.get-pool-info-token-price',
@@ -169,16 +221,16 @@ class PriceInfoFromDex(Model):
         return Some[PoolPriceInfo](some=_use_for())
 
 
-@Model.describe(slug='price.dex-blended-maybe',
-                version='0.1',
-                display_name='Token price - Credmark',
-                description='The Current Credmark Supported Price Algorithms',
-                developer='Credmark',
-                category='price',
-                subcategory='dex',
-                tags=['dex', 'price'],
-                input=Token,
-                output=Maybe[Price])
+@ Model.describe(slug='price.dex-blended-maybe',
+                 version='0.1',
+                 display_name='Token price - Credmark',
+                 description='The Current Credmark Supported Price Algorithms',
+                 developer='Credmark',
+                 category='price',
+                 subcategory='dex',
+                 tags=['dex', 'price'],
+                 input=Token,
+                 output=Maybe[Price])
 class PriceFromDexModelMaybe(Model, PriceWeight):
     """
     Return token's price
@@ -194,17 +246,17 @@ class PriceFromDexModelMaybe(Model, PriceWeight):
             raise
 
 
-@Model.describe(slug='price.dex-blended',
-                version='1.10',
-                display_name='Token price - Credmark',
-                description='The Current Credmark Supported Price Algorithms',
-                developer='Credmark',
-                category='price',
-                subcategory='dex',
-                tags=['dex', 'price'],
-                input=Token,
-                output=Price,
-                errors=PRICE_DATA_ERROR_DESC)
+@ Model.describe(slug='price.dex-blended',
+                 version='1.10',
+                 display_name='Token price - Credmark',
+                 description='The Current Credmark Supported Price Algorithms',
+                 developer='Credmark',
+                 category='price',
+                 subcategory='dex',
+                 tags=['dex', 'price'],
+                 input=Token,
+                 output=Price,
+                 errors=PRICE_DATA_ERROR_DESC)
 class PriceFromDexModel(Model, PriceWeight):
     """
     Return token's price
@@ -216,17 +268,10 @@ class PriceFromDexModel(Model, PriceWeight):
                                                 return_type=Some[PoolPriceInfo],
                                                 local=True).some
 
-        non_zero_pools = {ii.src for ii in all_pool_infos if ii.tick_liquidity > 0}
-        zero_pools = {ii.src for ii in all_pool_infos if ii.tick_liquidity == 0}
         pool_aggregator_input = PoolPriceAggregatorInput(
             some=all_pool_infos,
             token=input,
-            price_src=(f'{self.slug}|'
-                       f'Non-zero:{",".join(non_zero_pools)}|'
-                       f'Zero:{",".join(zero_pools)}'),
             weight_power=self.WEIGHT_POWER)
-        if len(all_pool_infos) == 0:
-            raise ModelRunError(f'No pool to aggregate for {input}')
 
         # return PoolPriceAggregator(self.context).run(pool_aggregator_input)
         return self.context.run_model('price.pool-aggregator',

--- a/models/credmark/protocols/credmark/cmk.py
+++ b/models/credmark/protocols/credmark/cmk.py
@@ -45,6 +45,6 @@ class CirculatingCMK(Model):
         cmk_token = Token(symbol='CMK')
 
         for addr in lockedAddresses:
-            supply = supply - cmk_token.balance_of(Address(addr))
+            supply = supply - cmk_token.balance_of(Address(addr).checksum)
 
         return {'result': supply}

--- a/models/credmark/protocols/credmark/vesting.py
+++ b/models/credmark/protocols/credmark/vesting.py
@@ -75,6 +75,7 @@ class CMKGetVestingAccounts(Model):
                         fromBlock=0,
                         toBlock=self.context.block_number
                     ).get_all_entries()
+
                 except ValueError:
                     # Some Eth node does not support the newer eth_newFilter method
                     try:

--- a/models/credmark/protocols/dexes/balancer/balancer_finance.py
+++ b/models/credmark/protocols/dexes/balancer/balancer_finance.py
@@ -75,7 +75,8 @@ class GetBalancerAllPools(Model):
         vault = Contract(address=Address(self.VAULT_ADDR[self.context.network]).checksum)
         with vault.ledger.events.PoolRegistered as q:
             df = q.select(columns=[q.EVT_BLOCK_NUMBER, q.POOLADDRESS],
-                          order_by=q.EVT_BLOCK_NUMBER, limit=5000).to_dataframe()
+                          order_by=q.EVT_BLOCK_NUMBER,
+                          limit=5000).to_dataframe()
 
         contracts = []
         for _n, r in df.iterrows():

--- a/models/credmark/protocols/dexes/curve/curve_finance.py
+++ b/models/credmark/protocols/dexes/curve/curve_finance.py
@@ -205,7 +205,7 @@ class CurveFinancePoolInfoTokens(Model):
                 except ContractLogicError:
                     break
 
-        balances_token = [t.balance_of_scaled(input.address) for t in tokens]
+        balances_token = [t.balance_of_scaled(input.address.checksum) for t in tokens]
 
         admin_fees = [bal_token-bal for bal, bal_token in zip(balances, balances_token)]
 

--- a/models/credmark/protocols/dexes/curve/curve_finance.py
+++ b/models/credmark/protocols/dexes/curve/curve_finance.py
@@ -178,7 +178,7 @@ class CurveFinancePoolInfoTokens(Model):
             try:
                 pool_addr = (registry.functions
                              .get_pool_from_lp_token(input.address.checksum).call())
-                if not pool_addr.is_null():
+                if not Address(pool_addr).is_null():
                     return self.context.run_model(self.slug,
                                                   input=Contract(address=Address(pool_addr)),
                                                   return_type=CurveFiPoolInfoToken)

--- a/models/credmark/protocols/dexes/sushiswap/sushiswap.py
+++ b/models/credmark/protocols/dexes/sushiswap/sushiswap.py
@@ -43,7 +43,7 @@ class SushiswapV2Factory(Model):
 class SushiswapGetPoolsForToken(Model, UniswapV2PoolMeta):
     def run(self, input: Token) -> Contracts:
         contract = Contract(**self.context.models(local=True).sushiswap.get_v2_factory())
-        return self.get_uniswap_pools(self.context, input, contract.address)
+        return self.get_uniswap_pools(self.context, input.address, contract.address)
 
 
 @Model.describe(slug="sushiswap.all-pools",
@@ -117,8 +117,7 @@ class SushiswapGetTokenPriceInfo(Model):
                                        local=True)
 
         model_slug = 'uniswap-v2.get-pool-price-info'
-        model_inputs = [DexPoolPriceInput(token=input,
-                                          pool=pool,
+        model_inputs = [DexPoolPriceInput(address=pool.address,
                                           price_slug='sushiswap.get-weighted-price')
                         for pool in pools]
 

--- a/models/credmark/protocols/dexes/uniswap/liquidity.py
+++ b/models/credmark/protocols/dexes/uniswap/liquidity.py
@@ -1,0 +1,279 @@
+from math import floor, log
+from typing import Dict, Optional
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from credmark.cmf.model import Model
+from credmark.cmf.types import Address, Contract, Token
+from credmark.dto import DTO, DTOField
+
+
+class V3PoolLiquidityByTicksInput(Contract):
+    min_tick: Optional[int] = DTOField(None, description='(Optional) minimal tick to search')
+    max_tick: Optional[int] = DTOField(None, description='(Optional) maximum tick to search')
+
+
+class V3PoolLiquidityByTicksOutput(DTO):
+    liquidity: Dict[int, int] = DTOField(description='Liquidity mapped to ticks')
+    change_on_tick: Dict[int, int] = DTOField(description='Liquidity change on every tick')
+    liquidity_pos_on_tick: Dict[int, int] = DTOField(description='Liquidity position on every tick')
+    current_tick: int
+    tick_spacing: int
+
+
+@Model.describe(slug='uniswap-v3.get-liquidity-by-ticks',
+                version='1.8',
+                display_name='Uniswap v3 - Liquidity',
+                description='Liquidity at every range - restored from Mint/Burn events',
+                category='protocol',
+                subcategory='uniswap-v3',
+                input=V3PoolLiquidityByTicksInput,
+                output=V3PoolLiquidityByTicksOutput)
+class UniswapV3LiquidityHistorical(Model):
+    MIN_TICK = -887272
+    MAX_TICK = 887272
+
+    def run(self, input: V3PoolLiquidityByTicksInput) -> V3PoolLiquidityByTicksOutput:
+        pool_contract = input
+
+        current_liquidity = pool_contract.functions.liquidity().call()
+        slot0 = pool_contract.functions.slot0().call()
+        current_tick = slot0[1]
+
+        tick_spacing = pool_contract.functions.tickSpacing().call()
+        tick_bottom = current_tick // tick_spacing * tick_spacing
+        tick_top = tick_bottom + tick_spacing
+        assert tick_bottom <= current_tick <= tick_top
+
+        liquidity_on_tick = {}
+        change_on_tick = {}
+        liquidity_pos_on_tick = {}
+
+        liquidity = current_liquidity
+        x = 0
+        tick_b = tick_bottom
+
+        min_tick = self.MIN_TICK if input.min_tick is None else input.min_tick
+        max_tick = self.MAX_TICK if input.max_tick is None else input.max_tick
+
+        while tick_b >= min_tick:
+            ticks = pool_contract.functions.ticks(tick_b).call()
+            if ticks[1] != 0:
+                change_on_tick[tick_b] = ticks[1]
+                liquidity -= ticks[1]
+                liquidity_on_tick[tick_b] = liquidity
+            if ticks[0] != 0:
+                liquidity_pos_on_tick[tick_b] = ticks[0]
+            x += 1
+            tick_b = tick_bottom - tick_spacing * x
+
+        liquidity_on_tick = dict(sorted(liquidity_on_tick.items()))
+        change_on_tick = dict(sorted(change_on_tick.items()))
+        liquidity_pos_on_tick = dict(sorted(liquidity_pos_on_tick.items()))
+
+        liquidity = current_liquidity
+        x = 1
+        tick_b = tick_bottom + tick_spacing
+        while tick_b <= max_tick:
+            ticks = pool_contract.functions.ticks(tick_b).call()
+            if ticks[1] != 0:
+                change_on_tick[tick_b] = ticks[1]
+                liquidity += ticks[1]
+                liquidity_on_tick[tick_b] = liquidity
+            if ticks[0] != 0:
+                liquidity_pos_on_tick[tick_b] = ticks[0]
+            x += 1
+            tick_b = tick_bottom + tick_spacing * x
+
+        return V3PoolLiquidityByTicksOutput(
+            liquidity=liquidity_on_tick,
+            change_on_tick=change_on_tick,
+            liquidity_pos_on_tick=liquidity_pos_on_tick,
+            current_tick=current_tick,
+            tick_spacing=tick_spacing)
+
+
+def plot_liquidity(context):
+    pool = Contract(address='0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640')
+
+    current_liquidity = pool.functions.liquidity().call()
+    _tick_spacing = pool.functions.tickSpacing().call()
+
+    slot0 = pool.functions.slot0().call()
+    current_tick = slot0[1]
+
+    out = context.run_model(
+        'uniswap-v3.get-liquidity-by-ticks',
+        {"address": "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640",
+         "min_tick": current_tick-1000,
+         "max_tick": current_tick+1000})
+
+    (pd.DataFrame([(int(k), int(v)) for k, v in out['liquidity'].items()],
+                  columns=['tick', 'liquidity'])
+        .plot('tick', 'liquidity')
+     )
+    plt.scatter(current_tick, current_liquidity, color='red')
+    plt.show()
+
+
+UNISWAP_BASE = 1.0001
+
+
+def tick_to_price(tick):
+    """
+    tick to price
+    """
+    return pow(UNISWAP_BASE, tick)
+
+
+def price_to_tick(price):
+    """
+    price to tick
+    """
+    return log(price) / log(UNISWAP_BASE)
+
+
+def get_amount_in_ticks(logger, pool_contract: 'Contract', token0: 'Token', token1: 'Token', change_on_tick: Dict[int, int], should_print_tick=False):
+    # pylint:disable=line-too-long
+    """
+    Reference: https://github.com/atiselsts/uniswap-v3-liquidity-math/blob/master/subgraph-liquidity-range-example.py
+    """
+
+    decimals0 = token0.decimals
+    decimals1 = token1.decimals
+
+    slot0 = pool_contract.functions.slot0().call()
+    current_tick = slot0[1]
+    current_price = tick_to_price(current_tick)
+    adjusted_current_price = current_price / (10 ** (decimals1 - decimals0))
+
+    tick_spacing = pool_contract.functions.tickSpacing().call()
+
+    current_range_bottom_tick = floor(current_tick / tick_spacing) * tick_spacing
+    current_price = tick_to_price(current_tick)
+
+    liquidity = 0
+
+    token_amounts = []
+
+    min_tick = min(change_on_tick.keys())
+    max_tick = max(change_on_tick.keys())
+
+    for tick in range(min_tick, max_tick, tick_spacing):
+        liquidity += change_on_tick.get(tick, 0)
+
+        tick_bottom = tick
+        tick_top = tick_bottom + tick_spacing
+
+        sa = tick_to_price(tick_bottom // 2)
+        sb = tick_to_price(tick_top // 2)
+
+        # Compute the amounts of tokens potentially in the range
+        amount1 = int(liquidity * (sb - sa))
+        amount0 = int(amount1 / (sb * sa))
+
+        if tick < current_range_bottom_tick:
+            token_amounts.append((tick, amount0, amount1, liquidity))
+        elif tick == current_range_bottom_tick:
+            # Print the real amounts of the two assets needed to be swapped to move out of the current tick range
+            sp = tick_to_price(current_tick / 2)
+            amount0 = int(liquidity * (sb - sp) / (sp * sb))
+            amount1 = int(liquidity * (sp - sa))
+
+            token_amounts.append((tick, amount0, amount1, liquidity))
+            logger.info(f"{amount0:.2f} {token0} and {amount1:.2f} {token1} remaining in the current tick range")
+        else:
+            token_amounts.append((tick, amount0, amount1, liquidity))
+            if should_print_tick:
+                adjusted_amount0 = amount0 / (10 ** decimals0)
+                adjusted_amount1 = amount1 / (10 ** decimals1)
+                logger.info(f"{adjusted_amount0:.2f} {token0} locked, potentially worth {adjusted_amount1:.2f} {token1}")
+
+        tick += tick_spacing
+
+    token0_bal = token0.balance_of(pool_contract.address.checksum)
+    token1_bal = token1.balance_of(pool_contract.address.checksum)
+    token0_dec = 10**decimals0
+    token1_dec = 10**decimals1
+
+    df_pool = (
+        pd.DataFrame(token_amounts, columns=['tick', 'token0', 'token1', 'liquidity'])
+        .assign(token0_locked=lambda x: x.token0,
+                token1_locked=lambda x: x.token1)
+        .assign(token0_locked=lambda x, t=current_range_bottom_tick: x.token0_locked.where(x.tick >= t, 0),
+                token1_locked=lambda x, t=current_range_bottom_tick: x.token1_locked.where(x.tick <= t, 0))
+        .assign(token0_scaled=lambda x, dec=token0_dec: x.token0 / dec,
+                token1_scaled=lambda x, dec=token1_dec: x.token1 / dec,
+                token0_prop=lambda x, bal=token0_bal: x.token0 / bal,
+                token1_prop=lambda x, bal=token1_bal: x.token1 / bal)
+        .assign(token0_locked_scaled=lambda x, dec=token0_dec: x.token0_locked / dec,
+                token1_locked_scaled=lambda x, dec=token1_dec: x.token1_locked / dec,
+                token0_locked_prop=lambda x, bal=token0_bal: x.token0_locked / bal,
+                token1_locked_prop=lambda x, bal=token1_bal: x.token1_locked / bal
+                )
+    )
+    return df_pool
+
+
+@ Model.describe(slug='uniswap-v3.get-amount-in-ticks',
+                 version='1.8',
+                 display_name='Uniswap v3 - Liquidity',
+                 description='Liquidity at every range - restored from Mint/Burn events',
+                 category='protocol',
+                 subcategory='uniswap-v3',
+                 input=V3PoolLiquidityByTicksInput,
+                 output=dict)
+class UniswapV3AmountInTicks(Model):
+    def run(self, input: V3PoolLiquidityByTicksInput) -> dict:
+        liquidity_by_ticks = self.context.run_model(
+            'uniswap-v3.get-liquidity-by-ticks', input, return_type=V3PoolLiquidityByTicksOutput)
+
+        pool_contract = input
+        token0_addr = pool_contract.functions.token0().call()
+        token1_addr = pool_contract.functions.token1().call()
+        token0 = Token(address=Address(token0_addr).checksum)
+        token1 = Token(address=Address(token1_addr).checksum)
+
+        df_pool = get_amount_in_ticks(self.logger, pool_contract, token0, token1, liquidity_by_ticks.change_on_tick)
+
+        breakpoint()
+
+        return df_pool.to_dict()
+
+
+def plot_liquidity_amount(context):
+    pool = Contract(address='0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640')
+
+    slot0 = pool.functions.slot0().call()
+    current_tick = slot0[1]
+
+    out = context.run_model(
+        'uniswap-v3.get-amount-in-ticks',
+        {"address": "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640",
+         "min_tick": current_tick-1000,
+         "max_tick": current_tick+1000},
+        block_number=12377278)
+
+    df_pool = pd.DataFrame(out)
+    df_pool.token0_locked_prop.sum()  # close to 1
+    df_pool.token1_locked_prop.sum()  # close to 1
+
+    (df_pool
+        .astype({'token0_locked': 'float64', 'token1_locked': 'float64'})
+        .plot(x='tick',
+              y=['liquidity', 'token0_locked', 'token1_locked'],
+              sharex=True,
+              subplots=True,
+              kind='line'))
+    plt.show()
+
+    out = context.run_model(
+        'uniswap-v3.get-amount-in-ticks',
+        {"address": "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640",
+         "min_tick": 186730,
+         "max_tick": 198080},
+        block_number=12377278)
+
+    out = context.run_model(
+        'uniswap-v3.get-amount-in-ticks',
+        {"address": "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640"})

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v2.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v2.py
@@ -167,7 +167,8 @@ class UniswapPoolPriceInfo(Model):
                                                    {'address': primary_address},
                                                    return_type=Price).price
                 if ref_price is None:
-                    raise ModelRunError(f'Can not retriev price for {Token(address=primary_address)}')
+                    raise ModelRunError(f'Can not retriev price for '
+                                        f'{Token(address=primary_address)}')
 
                 if token0.address == primary_address:
                     tick_price_usd0 = ref_price
@@ -465,7 +466,7 @@ class DexPoolSwapVolumeHistorical(Model):
                     with pool.ledger.events.TokenExchange as q:
                         df_all_swap_1 = (q.select(
                             aggregates=(
-                                [(f'sum({q[field]})', f'{q[field]}')
+                                [(q[field].as_integer().sum_(), q[field])
                                  for field in ['TOKENS_SOLD', 'TOKENS_BOUGHT']] +
                                 [(f'floor(({self.context.block_number} - {q.EVT_BLOCK_NUMBER}) / {input.interval}, 0)',
                                   'interval_n')] +
@@ -489,7 +490,7 @@ class DexPoolSwapVolumeHistorical(Model):
                     with pool.ledger.events.TokenExchangeUnderlying as q:
                         df_all_swap_2 = (q.select(
                             aggregates=(
-                                [(q[field].sum_().str(), f'{q[field]}')
+                                [(q[field].as_integer().sum_().str(), f'{q[field]}')
                                     for field in ['TOKENS_SOLD', 'TOKENS_BOUGHT']] +
                                 [(f'floor(({self.context.block_number} - {q.EVT_BLOCK_NUMBER}) / {input.interval}, 0)',
                                     'interval_n')] +

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v2.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v2.py
@@ -41,7 +41,7 @@ class UniswapV2PoolMeta:
 
                 pair_address = factory.functions.getPair(
                     model_input.address, token_address).call()
-                if not pair_address == Address.null():
+                if not Address(pair_address).is_null():
                     cc = Contract(address=pair_address)
                     try:
                         _ = cc.abi
@@ -53,7 +53,7 @@ class UniswapV2PoolMeta:
                 else:
                     pair_address = factory.functions.getPair(
                         token_address, model_input.address).call()
-                    if not pair_address == Address.null():
+                    if not Address(pair_address).is_null():
                         cc = Contract(address=pair_address)
                         try:
                             _ = cc.abi

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
@@ -357,7 +357,8 @@ class UniswapV3GetTokenPoolPriceInfo(Model):
         ref_price = 1.0
         weth_address = Token('WETH').address
 
-        # 1. If both are stablecoins (non-WETH): do nothing
+        # 1. If both are stablecoins (non-WETH): use the relative ratio between each other.
+        #    So we are able to support depegged SB (like USDT in May 13th 2022)
         # 2. If SB-WETH: use SB to price WETH
         # 3. If WETH-X: use WETH to price
         # 4. If SB-X: use SB to price

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
@@ -236,9 +236,24 @@ class UniswapV3GetPoolInfo(Model):
 
         # Below shall be equal for the tick liquidity
         # Reference: UniswapV3 whitepaper Eq. 2.2
-        assert np.isclose(
-            (in_tick_amount0 + liquidity / sb) * (in_tick_amount1 + liquidity * sa),
-            float(liquidity * liquidity))
+
+        # Disabled for some pools with small quantity of in_tick tokens.
+        # Example:
+        # uniswap-v3.get-pool-info -b 15301016
+        # -i '{"address":"0x5c0f97e0ed70e0163b799533ce142f650e39a3e6",
+        #      "price_slug": "uniswap-v3.get-weighted-price"}'
+
+        # assert np.isclose(
+        #     (in_tick_amount0 + liquidity / sb) * (in_tick_amount1 + liquidity * sa),
+        #    float(liquidity * liquidity))
+
+        ratio_left = (in_tick_amount0 + liquidity / sb) * (in_tick_amount1 + liquidity * sa)
+        ratio_right = float(liquidity * liquidity)
+        try:
+            assert np.isclose(ratio_left, ratio_right)
+        except AssertionError:
+            compare_ratio = ratio_left/ratio_right
+            assert 0.99 < compare_ratio < 1.01
 
         sa_p = self.tick_to_price((current_tick - 1) / 2)
         sb_p = self.tick_to_price((current_tick + 1) / 2)

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
@@ -85,7 +85,7 @@ class UniswapV3GetPoolsForToken(Model):
                             input.address.checksum,
                             primary_token.checksum,
                             fee).call()
-                        if pool != Address.null():
+                        if not Address(pool).is_null():
                             cc = Contract(address=pool, abi=UNISWAP_V3_POOL_ABI)
                             try:
                                 _ = cc.abi
@@ -99,7 +99,7 @@ class UniswapV3GetPoolsForToken(Model):
                                 input.address.checksum,
                                 primary_token.checksum,
                                 fee).call()
-                            if pool != Address.null():
+                            if not Address(pool).is_null():
                                 cc = Contract(address=pool, abi=UNISWAP_V3_POOL_ABI)
                                 try:
                                     _ = cc.abi

--- a/models/credmark/protocols/lending/aave/aave_v2.py
+++ b/models/credmark/protocols/lending/aave/aave_v2.py
@@ -108,7 +108,8 @@ class AaveV2GetLendingPool(Model):
     def run(self, input: EmptyInput) -> Contract:
         lending_pool_provider = self.context.run_model('aave-v2.get-lending-pool-provider',
                                                        input=EmptyInput(),
-                                                       return_type=Contract)
+                                                       return_type=Contract,
+                                                       local=True)
         lending_pool_address = lending_pool_provider.functions.getLendingPool().call()
         lending_pool_contract = Contract(address=lending_pool_address)
         _ = lending_pool_contract.abi
@@ -127,7 +128,8 @@ class AaveV2GetPriceOracle(Model):
     def run(self, input: EmptyInput) -> Contract:
         lending_pool_provider = self.context.run_model('aave-v2.get-lending-pool-provider',
                                                        input=EmptyInput(),
-                                                       return_type=Contract)
+                                                       return_type=Contract,
+                                                       local=True)
         price_oracle_address = lending_pool_provider.functions.getPriceOracle().call()
         price_oracle_contract = Contract(address=price_oracle_address)
         _ = price_oracle_contract.abi
@@ -144,7 +146,7 @@ class AaveV2GetPriceOracle(Model):
                 output=Price)
 class AaveV2GetOraclePrice(Model):
     def run(self, input: Token) -> Price:
-        oracle = Contract(**self.context.models.aave_v2.get_price_oracle())
+        oracle = Contract(**self.context.models(local=True).aave_v2.get_price_oracle())
         price = oracle.functions.getAssetPrice(input.address).call()
         source = oracle.functions.getSourceOfAsset(input.address).call()
         return Price(price=NativeToken().scaled(price), src=f'{self.slug}|{source}')
@@ -162,7 +164,8 @@ class AaveV2GetLiability(Model):
     def run(self, input) -> Portfolio:
         aave_lending_pool = self.context.run_model('aave-v2.get-lending-pool',
                                                    input=EmptyInput(),
-                                                   return_type=Contract)
+                                                   return_type=Contract,
+                                                   local=True)
         aave_lending_pool = get_eip1967_proxy_err(self.context,
                                                   self.logger,
                                                   aave_lending_pool.address,
@@ -193,7 +196,8 @@ class AaveV2GetTokenLiability(Model):
     def run(self, input: Contract) -> Position:
         aave_lending_pool = self.context.run_model('aave-v2.get-lending-pool',
                                                    input=EmptyInput(),
-                                                   return_type=Contract)
+                                                   return_type=Contract,
+                                                   local=True)
         aave_lending_pool = get_eip1967_proxy_err(self.context,
                                                   self.logger,
                                                   aave_lending_pool.address,
@@ -222,7 +226,8 @@ class AaveV2GetAssets(Model):
     def run(self, input: EmptyInput) -> Some[AaveDebtInfo]:
         aave_lending_pool = self.context.run_model('aave-v2.get-lending-pool',
                                                    input=EmptyInput(),
-                                                   return_type=Contract)
+                                                   return_type=Contract,
+                                                   local=True)
         aave_lending_pool = get_eip1967_proxy_err(self.context,
                                                   self.logger,
                                                   aave_lending_pool.address,
@@ -269,7 +274,8 @@ class AaveV2GetTokenAsset(Model):
     def run(self, input: Token) -> AaveDebtInfo:
         aave_lending_pool = self.context.run_model('aave-v2.get-lending-pool',
                                                    input=EmptyInput(),
-                                                   return_type=Contract)
+                                                   return_type=Contract,
+                                                   local=True)
         aave_lending_pool = get_eip1967_proxy_err(self.context,
                                                   self.logger,
                                                   aave_lending_pool.address,

--- a/models/credmark/protocols/lending/compound/compound_v2.py
+++ b/models/credmark/protocols/lending/compound/compound_v2.py
@@ -158,7 +158,13 @@ class CompoundV2AllPoolsInfo(Model):
                     raise ModelRunError('compose.map-inputs: output/error cannot be both None')
             return pool_infos
 
-        pool_infos = _use_compose()
+        def _use_for():
+            pool_infos = [self.context.run_model(model_slug, minput, return_type=CompoundV2PoolInfo)
+                          for minput in model_inputs]
+            return pool_infos
+
+        # pool_infos = _use_compose()
+        pool_infos = _use_for()
 
         ret = Some[CompoundV2PoolInfo](some=pool_infos)
         return ret

--- a/models/dtos/price.py
+++ b/models/dtos/price.py
@@ -102,6 +102,7 @@ class PoolPriceInfo(DTO):
 class PoolPriceAggregatorInput(Some[PoolPriceInfo]):
     token: Token
     weight_power: float = DTOField(1.0, ge=1.0)
+    debug: bool = DTOField(False, description='Turn on debug log')
 
 
 PRICE_DATA_ERROR_DESC = ModelDataErrorDesc(

--- a/models/dtos/price.py
+++ b/models/dtos/price.py
@@ -64,9 +64,7 @@ class PriceHistoricalInputs(Some[PriceInput], MapBlockTimeSeriesInput):
     endTimestamp: int = DTOField(0, hidden=True)
 
 
-class DexPoolPriceInput(DTO):
-    token: Token
-    pool: Contract
+class DexPoolPriceInput(Contract):
     price_slug: str
 
 
@@ -85,23 +83,25 @@ class PoolPriceInfo(DTO):
     @token1_decimals: token1's decimals
     @pool_address: pool's address
     """
-    class Meta(DTO):
-        liquidity: float
     src: str
-    price: float
-    tick_liquidity: float
+    price_usd0: float
+    price_usd1: float
+    one_tick_liquidity0: float
+    one_tick_liquidity1: float
+    full_tick_liquidity0: float
+    full_tick_liquidity1: float
     token0_address: Address
     token1_address: Address
     token0_symbol: str
     token1_symbol: str
     pool_address: Address
-    weth_multiplier: float
+    ref_price: float
+    tick_spacing: int
 
 
 class PoolPriceAggregatorInput(Some[PoolPriceInfo]):
     token: Token
     weight_power: float = DTOField(1.0, ge=1.0)
-    price_src: str
 
 
 PRICE_DATA_ERROR_DESC = ModelDataErrorDesc(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "models" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9.0,<3.11"
-credmark-model-framework = { git = "https://github.com/credmark/credmark-model-framework-py.git", tag = "0.8.30" }
+credmark-model-framework = { git = "https://github.com/credmark/credmark-model-framework-py.git", tag = "0.8.31" }
 numpy = ">=1.21.0"
 matplotlib = ">=3.5.1"
 pandas = ">=1.3.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/credmark/credmark-model-framework-py.git@0.8.30
+git+https://github.com/credmark/credmark-model-framework-py.git@0.8.31
 # data libraries
 numpy>=1.21.0
 matplotlib>=3.5.1

--- a/test/test_dashboard.py
+++ b/test/test_dashboard.py
@@ -107,9 +107,9 @@ def run_test_uni(self, pool_n, pool, test_volume):
                        {"pool_info_model": "uniswap-v2.pool-tvl", "interval": 7200, "count": 2, "address": pool},
                        block_number=block_number)
 
-    self.run_model('dex.pool-volume',
-                   {"pool_info_model": "uniswap-v2.pool-tvl", "interval": 7200, "address": pool},
-                   block_number=block_number)
+        self.run_model('dex.pool-volume',
+                       {"pool_info_model": "uniswap-v2.pool-tvl", "interval": 7200, "address": pool},
+                       block_number=block_number)
 
     self.run_model('finance.var-dex-lp',
                    {"pool": {"address": pool}, "window": "7 days", "interval": 1,
@@ -144,19 +144,19 @@ def run_test_curve(self, pool_n, pool, test_volume):
 for n, addr in enumerate(TestDashboard.UNIV2_POOLS):
     setattr(TestDashboard,
             f'test_univ2_{n+1}',
-            lambda self, pool_n=n, pool=addr: run_test_uni(self, pool_n, pool, pool_n < 10))
+            lambda self, pool_n=n, pool=addr: run_test_uni(self, pool_n, pool, pool_n < 4))
 
 for n, addr in enumerate(TestDashboard.UNIV3_POOLS):
     setattr(TestDashboard,
             f'test_univ3_{n+1}',
-            lambda self, pool_n=n, pool=addr: run_test_uni(self, pool_n, pool, pool_n < 10))
+            lambda self, pool_n=n, pool=addr: run_test_uni(self, pool_n, pool, pool_n < 4))
 
 for n, addr in enumerate(TestDashboard.SUSHI_POOLS):
     setattr(TestDashboard,
             f'test_sushi_{n+1}',
-            lambda self, pool_n=n, pool=addr: run_test_uni(self, pool_n, pool, pool_n < 10))
+            lambda self, pool_n=n, pool=addr: run_test_uni(self, pool_n, pool, pool_n < 4))
 
 for n, addr in enumerate(TestDashboard.CURVE_POOLS):
     setattr(TestDashboard,
             f'test_curve_{n+1}',
-            lambda self, pool_n=n, pool=addr: run_test_curve(self, pool_n, pool, pool_n < 10))
+            lambda self, pool_n=n, pool=addr: run_test_curve(self, pool_n, pool, pool_n < 4))

--- a/test/test_dashboard.py
+++ b/test/test_dashboard.py
@@ -75,6 +75,16 @@ class TestDashboard(CMKTest):
                         "window": "23 days", "interval": 10, "confidence": 0.01, "lower_range": 0.01, "upper_range": 0.01},
                        block_number=block_number)
 
+        self.run_model('finance.var-dex-lp',
+                       {"pool": {"address": "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"},
+                        "window": "90 days", "interval": 10, "confidence": 0.01, "lower_range": 0.01, "upper_range": 0.01},
+                       block_number=15263892)
+
+        self.run_model('finance.var-dex-lp',
+                       {"pool": {"address": "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8"},
+                        "window": "90 days", "interval": 10, "confidence": 0.01, "lower_range": 0.01, "upper_range": 0.01},
+                       block_number=15263892)
+
         for range_of_pool in [0.01, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0]:
             print(f'LP VaR Range: {range_of_pool}')
             self.run_model('finance.var-dex-lp',

--- a/test/test_sushiswap.py
+++ b/test/test_sushiswap.py
@@ -8,10 +8,11 @@ class TestSushiSwap(CMKTest):
         self.title('SushiSwap')
 
         # sushiswap.get-pool-info-token-price, uniswap-v2.get-pool-price-info
-        self.run_model('sushiswap.get-weighted-price', {"symbol": "USDC"})
-        self.run_model('sushiswap.get-weighted-price', {"symbol": "AAVE"})
-        self.run_model('sushiswap.get-weighted-price', {"symbol": "DAI"})
         self.run_model('sushiswap.get-weighted-price', {"symbol": "WETH"})
+        self.run_model('sushiswap.get-weighted-price', {"symbol": "USDC"})
+        self.run_model('sushiswap.get-weighted-price', {"symbol": "USDT"})
+        self.run_model('sushiswap.get-weighted-price', {"symbol": "DAI"})
+        self.run_model('sushiswap.get-weighted-price', {"symbol": "AAVE"})
         self.run_model('sushiswap.get-weighted-price', {"symbol": "MKR"})
         self.run_model('sushiswap.all-pools', {})
         self.run_model('sushiswap.get-pool', {"token0": {"symbol": "DAI"}, "token1": {"symbol": "WETH"}})

--- a/test/test_uniswap.py
+++ b/test/test_uniswap.py
@@ -34,5 +34,20 @@ class TestUniswap(CMKTest):
         # WETH/CMK pool: 0x59e1f901b5c33ff6fae15b61684ebf17cca7b9b3
         self.run_model('uniswap-v3.get-pool-info', {"address": "0x59e1f901b5c33ff6fae15b61684ebf17cca7b9b3"})
 
-        self.run_model('uniswap-v2.get-pool-info-token-price', {"address":"0x853d955acef822db058eb8505911ed77f175b99e"}, block_number=15048685)
-        self.run_model('uniswap-v2.get-pool-info-token-price', {"address":"0x853d955acef822db058eb8505911ed77f175b99e"}, block_number=14048685)
+        self.run_model('uniswap-v2.get-pool-info-token-price',
+                       {"address": "0x853d955acef822db058eb8505911ed77f175b99e"}, block_number=15048685)
+        self.run_model('uniswap-v2.get-pool-info-token-price',
+                       {"address": "0x853d955acef822db058eb8505911ed77f175b99e"}, block_number=14048685)
+
+        # liquidity
+        self.run_model('uniswap-v3.get-liquidity-by-ticks',
+                       {"address": "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", "min_tick": 202000, "max_tick": 203000},
+                       block_number=15276693)
+
+        current_tick = 202180
+
+        self.run_model('uniswap-v3.get-amount-in-ticks',
+                       {"address": "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640",
+                        "min_tick": current_tick-1000,
+                        "max_tick": current_tick+1000},
+                       block_number=12377278)

--- a/test/test_uniswap.py
+++ b/test/test_uniswap.py
@@ -14,20 +14,25 @@ class TestUniswap(CMKTest):
         self.run_model('uniswap.router', {})
 
         self.title('Uniswap V2')
-        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "USDC"})  # uniswap-v2.get-pool-info-token-price
-        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "AAVE"})
-        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "DAI"})
         self.run_model('uniswap-v2.get-weighted-price', {"symbol": "WETH"})
+        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "USDT"})  # uniswap-v2.get-pool-info-token-price
+        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "USDC"})
+        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "DAI"})
+        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "AAVE"})
+        self.run_model('uniswap-v2.get-weighted-price', {"symbol": "MIM"})
         self.run_model('uniswap-v2.get-weighted-price', {"symbol": "MKR"})
         # 0xD533a949740bb3306d119CC777fa900bA034cd52: Curve DAO Token (CRV)
         self.run_model('uniswap-v2.get-pools', {"address": "0xD533a949740bb3306d119CC777fa900bA034cd52"})
 
         self.title('Uniswap V3')
         # uniswap-v3.get-pool-info, uniswap-v3.get-pool-info-token-price
+        self.run_model('uniswap-v3.get-weighted-price', {"symbol": "WETH"})
+        self.run_model('uniswap-v3.get-weighted-price', {"symbol": "USDT"})
         self.run_model('uniswap-v3.get-weighted-price', {"symbol": "USDC"})
+        self.run_model('uniswap-v3.get-weighted-price', {"symbol": "DAI"})
+        self.run_model('uniswap-v3.get-weighted-price', {"symbol": "MIM"})
         self.run_model('uniswap-v3.get-weighted-price', {"symbol": "AAVE"})  # uniswap-v3.get-pool-info
-        self.run_model('uniswap-v3.get-weighted-price', {"symbol": "DAI"})  # uniswap-v3.get-pool-info
-        self.run_model('uniswap-v3.get-weighted-price', {"symbol": "WETH"})  # uniswap-v3.get-pool-info
+
         self.run_model('uniswap-v3.get-weighted-price', {"symbol": "MKR"})  # uniswap-v3.get-pool-info
         self.run_model('uniswap-v3.get-weighted-price', {"symbol": "CMK"})  # uniswap-v3.get-pool-info
         self.run_model('uniswap-v3.get-pools', {"symbol": "MKR"})


### PR DESCRIPTION
- use address.is_null()
- add legder for vesting model
- use contract.fetch_evetns
- add v3 liquidity model
- overhaul Dex price model
1. Use 1-tick liquidity across for v2/v3/sushi pools
2. uniswap-v2/v3.get-pool-price-info is neutral to the pricing token. Leave the liquidity selection and weight to `aggregator`.
3. Support SB not always being 1

For a pool,
1. If both are stablecoins (non-WETH): do nothing, use the relative ratio between each other. Able to support depegged SB (like USDT in May 13th)
2. If SB-WETH: use SB to price WETH
3. If WETH-X: use WETH to price
4. If SB-X: use SB to price

- more tests