### PR TITLE
Added aave account info (balance and debt)

### DIFF
--- a/models/credmark/tokens/netflow.py
+++ b/models/credmark/tokens/netflow.py
@@ -1,3 +1,4 @@
+# pylint:disable=line-too-long
 from typing import List, Union
 from credmark.cmf.model import Model
 from credmark.cmf.model.errors import ModelRunError
@@ -214,6 +215,7 @@ class TokenVolumeSegmentBlock(Model):
             with self.context.ledger.Transaction.as_('t') as t,\
                     self.context.ledger.Block.as_('s') as s,\
                     self.context.ledger.Block.as_('e') as e:
+
                 df = s.select(
                     aggregates=[
                         (s.NUMBER, 'from_block'),
@@ -223,8 +225,8 @@ class TokenVolumeSegmentBlock(Model):
                         (t.VALUE.sum_(), 'sum_value')
                     ],
                     joins=[
-                        (e, e.NUMBER.eq(s.NUMBER.plus_(block_seg).minus_(1))),
-                        (JoinType.LEFT_OUTER, t, t.BLOCK_NUMBER.between_(s.NUMBER, e.NUMBER)
+                        (e, e.NUMBER.eq(s.NUMBER.plus_(str(block_seg)).minus_(str(1)))),
+                        (JoinType.LEFT_OUTER, t, t.field(f'{t.BLOCK_NUMBER} between {s.NUMBER} and {e.NUMBER}')
                          .and_(t.TO_ADDRESS.eq(input.netflow_address)
                                .or_(t.FROM_ADDRESS.eq(input.netflow_address)).parentheses_()))
                     ],
@@ -249,8 +251,8 @@ class TokenVolumeSegmentBlock(Model):
                         (t.VALUE.sum_(), 'sum_value')
                     ],
                     joins=[
-                        (e, e.NUMBER.eq(s.NUMBER.plus_(block_seg).minus_(1))),
-                        (JoinType.LEFT_OUTER, t, t.BLOCK_NUMBER.between_(s.NUMBER, e.NUMBER)
+                        (e, e.NUMBER.eq(s.NUMBER.plus_(str(block_seg)).minus_(str(1)))),
+                        (JoinType.LEFT_OUTER, t, t.field(f'{t.BLOCK_NUMBER} between {s.NUMBER} and {e.NUMBER}')
                          .and_(t.TOKEN_ADDRESS.eq(token_address))
                          .and_(t.TO_ADDRESS.eq(input.netflow_address)
                                .or_(t.FROM_ADDRESS.eq(input.netflow_address)).parentheses_()))

--- a/models/credmark/tokens/volume.py
+++ b/models/credmark/tokens/volume.py
@@ -1,4 +1,4 @@
-# pylint: disable=locally-disabled, unused-import, no-member
+# pylint: disable=locally-disabled, unused-import, no-member, line-too-long
 from typing import List, Union
 from credmark.cmf.model import Model
 from credmark.cmf.model.errors import ModelRunError
@@ -211,8 +211,8 @@ class TokenVolumeSegmentBlock(Model):
                         (t.VALUE.sum_(), 'sum_value')
                     ],
                     joins=[
-                        (e, e.NUMBER.eq(s.NUMBER.plus_(block_seg).minus_(1))),
-                        (JoinType.LEFT_OUTER, t, t.BLOCK_NUMBER.between_(s.NUMBER, e.NUMBER))
+                        (e, e.NUMBER.eq(s.NUMBER.plus_(str(block_seg)).minus_(str(1)))),
+                        (JoinType.LEFT_OUTER, t, t.field(f'{t.BLOCK_NUMBER} between {s.NUMBER} and {e.NUMBER}'))
                     ],
                     group_by=[s.NUMBER, s.TIMESTAMP, e.NUMBER, e.TIMESTAMP],
                     having=s.NUMBER.ge(block_start).and_(s.NUMBER.lt(
@@ -234,8 +234,8 @@ class TokenVolumeSegmentBlock(Model):
                         (t.VALUE.sum_(), 'sum_value')
                     ],
                     joins=[
-                        (e, e.NUMBER.eq(s.NUMBER.plus_(block_seg).minus_(1))),
-                        (JoinType.LEFT_OUTER, t, t.BLOCK_NUMBER.between_(s.NUMBER, e.NUMBER)
+                        (e, e.NUMBER.eq(s.NUMBER.plus_(str(block_seg)).minus_(str(1)))),
+                        (JoinType.LEFT_OUTER, t, t.field(f'{t.BLOCK_NUMBER} between {s.NUMBER} and {e.NUMBER}')
                          .and_(t.TOKEN_ADDRESS.eq(token_address)))
                     ],
                     group_by=[s.NUMBER, s.TIMESTAMP, e.NUMBER, e.TIMESTAMP],

--- a/test/test_aave.py
+++ b/test/test_aave.py
@@ -27,3 +27,6 @@ class TestAAVE(CMFTest):
         self.run_model('aave-v2.lending-pool-assets', {}, block_number=12770589)
 
         self.run_model('aave-v2.lending-pool-assets-portfolio', {}, block_number=12770589)
+
+        self.run_model('aave-v2.account-info',
+                       {"address": "0x4a49985b14bd0ce42c25efde5d8c379a48ab02f3"}, block_number=16325819)

--- a/test/test_polygon.py
+++ b/test/test_polygon.py
@@ -6,7 +6,7 @@ from cmf_test import CMFTest
 # credmark-dev run price.oracle-chainlink -i '{"base":"0x1ba42e5193dfa8b03d15dd1b86a3113bbbef8eeb"}' -b 23523151 -c 137 -l "*" -j --api_url=http://localhost:8700
 class TestPolygon(CMFTest):
     def test(self):
-        self.title('BSC')
+        self.title('Polygon')
 
         self.run_model('price.oracle-chainlink',
                        {"base": "0x1ba42e5193dfa8b03d15dd1b86a3113bbbef8eeb"}, block_number=36286847, chain_id=137)


### PR DESCRIPTION
## Objective
Build models to get account info (supplied and borrowed tokens) of AAVE-V2 protocol

## Work Done
Used .getUserReserveData endpoint on the AAVE-V2 protocolDataProvider contract to pull information on account balance and debt, then get the latest price of the tokens that the user has borrowed or supplied.

## Other note
This is the first step of the model. The next steps are:
- lowest values (24H and since supplied) of supplied tokens
- supply APY
- total interest earned
- borrowing interest rate
- borrowing liquidity threshold
- AAVE staking rewards earned/ pending to claim