### PR TITLE
Add models for user summary and reserve token configurations

### DIFF
--- a/models/credmark/protocols/lending/aave/aave_v2.py
+++ b/models/credmark/protocols/lending/aave/aave_v2.py
@@ -483,7 +483,8 @@ class AaveV2GetReserveConfigurationData(Model):
             return_type=Contract,
             local=True,
         )
-        config_data = protocolDataProvider.functions.getReserveConfigurationData(input.address).call()
+        config_data = protocolDataProvider.functions\
+            .getReserveConfigurationData(input.address).call()
 
         keys_need_to_be_decimal = ['ltv',
                                    'liquidationThreshold',

--- a/models/credmark/protocols/lending/aave/aave_v2.py
+++ b/models/credmark/protocols/lending/aave/aave_v2.py
@@ -463,3 +463,49 @@ class AaveV2GetTokenAsset(Model):
         else:
             raise ModelRunError(f'Unable to obtain {totalStableDebt=} and {totalVariableDebt=} '
                                 f'for {aToken.address=}')
+
+
+@Model.describe(
+    slug="aave-v2.reserve-config",
+    version="0.1",
+    display_name="Aave V2 reserve configuration data",
+    description="Aave V2 metadata of the inputted reserve token",
+    category="protocol",
+    subcategory="aave-v2",
+    input=Token,
+    output=dict,
+)
+class AaveV2GetReserveConfigurationData(Model):
+    def run(self, input: Token) -> dict:
+        protocolDataProvider = self.context.run_model(
+            "aave-v2.get-protocol-data-provider",
+            input=EmptyInput(),
+            return_type=Contract,
+            local=True,
+        )
+        config_data = protocolDataProvider.functions.getReserveConfigurationData(input.address).call()
+
+        keys_need_to_be_decimal = ['ltv',
+                                   'liquidationThreshold',
+                                   'liquidationBonus',
+                                   'reserveFactor']
+
+        keys = ['decimals',
+                'ltv',
+                'liquidationThreshold',
+                'liquidationBonus',
+                'reserveFactor',
+                'usageAsCollateralEnabled',
+                'borrowingEnabled',
+                'stableBorrowRateEnabled',
+                'isActive',
+                'isFrozen']
+
+        reserve_config_data = {}
+        for key, value in zip(keys, config_data):
+            if key in keys_need_to_be_decimal:
+                reserve_config_data[key] = value/10000
+            else:
+                reserve_config_data[key] = value
+
+        return reserve_config_data

--- a/test/test_aave.py
+++ b/test/test_aave.py
@@ -30,3 +30,15 @@ class TestAAVE(CMFTest):
 
         self.run_model('aave-v2.account-info',
                        {"address": "0x4a49985b14bd0ce42c25efde5d8c379a48ab02f3"}, block_number=16325819)
+
+    def test_reserve(self):
+        self.run_model('aave-v2.reserve-config', {'symbol': 'AAVE'}, block_number = 16462000)
+        self.run_model('aave-v2.reserve-config', {'symbol': 'CRV'}, block_number = 16462000)
+        self.run_model('aave-v2.reserve-config', {'symbol': 'LINK'}, block_number = 16462000)
+
+    def test_acccount(self):
+        self.run_model('aave-v2.account-info',
+                       {"address": "0x4a49985b14bd0ce42c25efde5d8c379a48ab02f3"}, block_number=16325819)
+
+        self.run_model('aave-v2.account-summary',
+                       {"address": "0x4a49985b14bd0ce42c25efde5d8c379a48ab02f3"}, block_number=16325819)


### PR DESCRIPTION
Added aave-v2.reserve-config model for reserve token configurations:
- decimals
- ltv
-liquidationThreshold
- liquidationBonus
- reserveFactor
- usageAsCollateralEnabled
- borrowingEnabled
- stableBorrowRateEnabled
- isActive
- isFrozen

Added aave-v2.account-summary:
- totalCollateralETH
- totalDebtETH
- availableBorrowsETH
- currentLiquidationThreshold
- ltv
- healthFactor
