### PR TITLE
Fix price v2

### DIFF
--- a/models/contrib/mega/convex.py
+++ b/models/contrib/mega/convex.py
@@ -10,19 +10,16 @@ class ConvexPoolInput(DTO):
     reward: Address
 
 
-@Model.describe(
-    slug="contrib.curve-convex-yield",
-    display_name="APR for Convex pool",
-    description=(
-        "base, crv, cvx apr for convex pool"
-    ),
-    input=ConvexPoolInput,
-    version="1.1",
-    developer="megaflare14",
-    category="protocol",
-    subcategory="curve",
-    output=dict,
-)
+@Model.describe(slug="contrib.curve-convex-yield",
+                display_name="APR for Convex pool",
+                description="base, crv, cvx apr for convex pool",
+                input=ConvexPoolInput,
+                version="1.1",
+                developer="megaflare14",
+                category="protocol",
+                subcategory="curve",
+                output=dict,
+                )
 class ConvexPoolApr(Model):
     # This is a re-implementation of the convex subgraph from:
     # https://github.com/convex-community/convex-subgraph/blob/e9c5cdfae055802af99b545739d9cf67a2a4c2cd/subgraphs/curve-pools/src/services/pools.ts#L253

--- a/models/credmark/price/dex.py
+++ b/models/credmark/price/dex.py
@@ -169,7 +169,7 @@ class DexWeightedPrice(Model):
 
 
 @Model.describe(slug='uniswap-v3.get-weighted-price-maybe',
-                version='1.10',
+                version='1.11',
                 display_name='Uniswap v3 - get price weighted by liquidity',
                 description='The Uniswap v3 pools that support a token contract',
                 category='protocol',
@@ -192,7 +192,7 @@ class UniswapV3WeightedPriceMaybe(DexWeightedPrice):
 
 
 @Model.describe(slug='uniswap-v3.get-weighted-price',
-                version='1.10',
+                version='1.11',
                 display_name='Uniswap v3 - get price weighted by liquidity',
                 description='The Uniswap v3 pools that support a token contract',
                 category='protocol',
@@ -207,7 +207,7 @@ class UniswapV3WeightedPrice(DexWeightedPrice):
 
 
 @Model.describe(slug='uniswap-v2.get-weighted-price',
-                version='1.10',
+                version='1.11',
                 display_name='Uniswap v2 - get price weighted by liquidity',
                 description='The Uniswap v2 pools that support a token contract',
                 category='protocol',
@@ -222,7 +222,7 @@ class UniswapV2WeightedPrice(DexWeightedPrice):
 
 
 @Model.describe(slug='sushiswap.get-weighted-price',
-                version='1.10',
+                version='1.11',
                 display_name='Sushi v2 (Uniswap V2) - get price weighted by liquidity',
                 description='The Sushi v2 pools that support a token contract',
                 category='protocol',
@@ -305,7 +305,7 @@ class PriceInfoFromDex(Model):
 
 
 @Model.describe(slug='price.dex-blended',
-                version='1.21',
+                version='1.22',
                 display_name='Credmark Token Price from Dex',
                 description='The Current Credmark Supported Price Algorithms',
                 developer='Credmark',

--- a/models/credmark/protocols/dexes/sushiswap/sushiswap.py
+++ b/models/credmark/protocols/dexes/sushiswap/sushiswap.py
@@ -57,7 +57,7 @@ class SushiswapGetPoolsForToken(Model, UniswapV2PoolMeta):
 
 
 @Model.describe(slug='sushiswap.get-ring0-ref-price',
-                version='0.3',
+                version='0.5',
                 display_name='Uniswap v2 Token Pools',
                 description='The Uniswap v2 pools that support a token contract',
                 category='protocol',

--- a/models/credmark/protocols/dexes/sushiswap/sushiswap.py
+++ b/models/credmark/protocols/dexes/sushiswap/sushiswap.py
@@ -57,7 +57,7 @@ class SushiswapGetPoolsForToken(Model, UniswapV2PoolMeta):
 
 
 @Model.describe(slug='sushiswap.get-ring0-ref-price',
-                version='0.1',
+                version='0.3',
                 display_name='Uniswap v2 Token Pools',
                 description='The Uniswap v2 pools that support a token contract',
                 category='protocol',

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v2.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v2.py
@@ -169,15 +169,16 @@ class UniswapV2PoolMeta:
                 valid_tokens.add(token0_address)
                 valid_tokens.add(token1_address)
 
-        breakpoint()
-
         valid_tokens_list = list(valid_tokens)
-        for token0_address, token1_address in missing_relations:
-            assert len(ring0_tokens) == 3
-            other_token = list(set(ring0_tokens) - {token0_address, token1_address})[0]
-            ratios[(token0_address, token1_address)] = ratios[(token0_address, other_token)] * \
-                ratios[(other_token, token1_address)]
-            ratios[(token1_address, token0_address)] = 1 / ratios[(token0_address, token1_address)]
+        if len(valid_tokens_list) == len(ring0_tokens):
+            try:
+                assert len(ring0_tokens) == 3
+            except AssertionError:
+                raise ModelDataError('Not implemented Calculate for missing relations for more than 3 ring0 tokens')
+            for token0_address, token1_address in missing_relations:
+                other_token = list(set(ring0_tokens) - {token0_address, token1_address})[0]
+                ratios[(token0_address, token1_address)] = ratios[(token0_address, other_token)] * \
+                    ratios[(other_token, token1_address)]
 
         candidate_prices = []
         for pivot_token in valid_tokens_list:
@@ -188,13 +189,15 @@ class UniswapV2PoolMeta:
                 ((candidate_price.max() / candidate_price.min(), -candidate_price.max(), candidate_price.min()),
                  candidate_price / candidate_price.max()))
 
+        ring0_token_symbols = [Token(t).symbol for t in ring0_tokens]
+
         return dict(zip(
             valid_tokens_list,
-            sorted(candidate_prices, key=lambda x: x[0])[0][1]))
+            sorted(candidate_prices, key=lambda x: x[0])[0][1])) | dict(zip(ring0_token_symbols, ring0_tokens))
 
 
 @Model.describe(slug='uniswap-v2.get-ring0-ref-price',
-                version='0.4',
+                version='0.5',
                 display_name='Uniswap v2 Ring0 Reference Price',
                 description='The Uniswap v2 pools that support the ring0 tokens',
                 category='protocol',

--- a/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
+++ b/models/credmark/protocols/dexes/uniswap/uniswap_v3.py
@@ -107,7 +107,7 @@ class UniswapV3GetPools(Model):
 
 
 @Model.describe(slug='uniswap-v3.get-ring0-ref-price',
-                version='0.3',
+                version='0.5',
                 display_name='Uniswap v3 Ring0 Reference Price',
                 description='The Uniswap v3 pools that support the ring0 tokens',
                 category='protocol',
@@ -126,6 +126,8 @@ class UniswapV3GetRing0RefPrice(Model):
                                               local=True).some
 
         ratios = {}
+        valid_tokens = set()
+        missing_relations = []
         for token0_address in ring0_tokens:
             for token1_address in ring0_tokens:
                 # Uniswap builds pools with token0 < token1
@@ -133,6 +135,10 @@ class UniswapV3GetRing0RefPrice(Model):
                     continue
                 token_pairs = [(token0_address, token1_address)]
                 pools = get_uniswap_v3_pools_by_pair(self.context, factory_addr, token_pairs)
+
+                if len(pools.contracts) == 0:
+                    missing_relations.extend([(token0_address, token1_address), (token1_address, token0_address)])
+                    continue
 
                 pools_info = [self.context.run_model('uniswap-v3.get-pool-info', input=p) for p in pools.contracts]
                 pools_info_sel = [[p.address,
@@ -153,12 +159,22 @@ class UniswapV3GetRing0RefPrice(Model):
 
                 ratios[(token0_address, token1_address)] = ratio0
                 ratios[(token1_address, token0_address)] = ratio1
+                valid_tokens.add(token0_address)
+                valid_tokens.add(token1_address)
+
+        valid_tokens_list = list(valid_tokens)
+        for token0_address, token1_address in missing_relations:
+            assert len(ring0_tokens) == 3
+            other_token = list(set(ring0_tokens) - {token0_address, token1_address})[0]
+            ratios[(token0_address, token1_address)] = ratios[(token0_address, other_token)] * \
+                ratios[(other_token, token1_address)]
+            ratios[(token1_address, token0_address)] = 1 / ratios[(token0_address, token1_address)]
 
         candidate_prices = []
-        for pivot_token in ring0_tokens:
+        for pivot_token in valid_tokens_list:
             candidate_price = np.array([ratios[(token, pivot_token)]
-                                        if token != pivot_token else 1.0
-                                        for token in ring0_tokens])
+                                        if token != pivot_token else 1
+                                        for token in valid_tokens_list])
             candidate_prices.append(
                 ((candidate_price.max() / candidate_price.min(), -candidate_price.max(), candidate_price.min()),
                  candidate_price / candidate_price.max()))

--- a/models/credmark/protocols/lending/aave/aave_v2.py
+++ b/models/credmark/protocols/lending/aave/aave_v2.py
@@ -265,7 +265,8 @@ class AaveV2GetLendingPool(Model):
                                                        input=EmptyInput(),
                                                        return_type=Contract,
                                                        local=True)
-        return Contract(address=lending_pool_provider)
+        lending_pool_address = lending_pool_provider.functions.getLendingPool().call()
+        return Contract(address=lending_pool_address)
 
 
 @Model.describe(slug="aave-v2.get-price-oracle",

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -15,9 +15,12 @@ class TestExample(CMFTest):
                        {"address": "0xD51a44d3FaE010294C616388b506AcdA1bfAAE46"})
 
         self.title('Example')
+
         self.run_model('example.all', {})  # example.contract, example.ledger-transactions, example.block-time
+
         self.run_model('example.model', {})
         self.run_model('example.model-run', {})
+
         self.run_model('example.contract', {})
 
         self.run_model('example.data-error-1', {}, exit_code=3)


### PR DESCRIPTION
Among the ring0 tokens, in the early time, they may not be connected to each in pools.

E.g. For token A, B, C.

There are pools of A-B, B-C but no A-C. So we derive A-C ratio from A-B and B-C.

The current code only support for 3-token case.